### PR TITLE
feat!: remove default .docsignore value from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - 🎯 AST-based symbol searching for TypeScript/JavaScript
 - 📝 Interactive fix mode with colored diffs
 - 🎨 Beautiful diff display
-- 🚫 .docsignore support for excluding files
+- 🚫 Ignore file support for excluding files
 
 ## Installation
 
@@ -171,7 +171,7 @@ Create `.coderefrc.json` in your project root:
 {
   "projectRoot": ".",
   "docsDir": "docs",
-  "ignoreFile": ".docsignore"
+  "ignoreFile": ".gitignore"
 }
 ```
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -8,7 +8,7 @@ Create `.coderefrc.json` in your project root:
 {
   "projectRoot": ".",
   "docsDir": "docs",
-  "ignoreFile": ".docsignore",
+  "ignoreFile": ".gitignore",
   "ignorePatterns": ["**/*.draft.md"],
   "verbose": false
 }
@@ -55,14 +55,17 @@ The tool loads configuration from multiple sources with the following precedence
 #### `ignoreFile`
 
 - **Type**: `string` (optional)
-- **Default**: `".docsignore"`
+- **Default**: `undefined`
 - **Description**: Path to ignore file relative to `projectRoot`. The file follows `.gitignore` syntax.
 
 ```json
 {
-  "ignoreFile": ".docsignore"
+  "ignoreFile": ".gitignore"
 }
 ```
+
+> **Note**: Prior to version 0.2.0, the default value was `.docsignore`.
+> If you want to continue using `.docsignore`, explicitly set `ignoreFile: '.docsignore'` in your configuration.
 
 #### `ignorePatterns`
 
@@ -161,7 +164,7 @@ Configuration with custom ignore patterns and verbose output:
 {
   "projectRoot": ".",
   "docsDir": "documentation",
-  "ignoreFile": ".docsignore",
+  "ignoreFile": ".gitignore",
   "ignorePatterns": ["**/*.draft.md", "**/archive/**", "**/_*.md"],
   "verbose": true
 }
@@ -175,7 +178,7 @@ Configuration for a monorepo with multiple documentation directories:
 {
   "projectRoot": "packages/my-package",
   "docsDir": "docs",
-  "ignoreFile": "../../.docsignore"
+  "ignoreFile": "../../.gitignore"
 }
 ```
 
@@ -217,9 +220,9 @@ Alternatively, you can define configuration in `package.json`:
 
 ## Ignore Files
 
-### .docsignore Syntax
+### Ignore File Syntax
 
-The `.docsignore` file follows the same syntax as `.gitignore`:
+The ignore file follows the same syntax as `.gitignore`:
 
 ```
 # Ignore draft files

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -103,14 +103,14 @@ export async function main(args: string[] = process.argv.slice(2)): Promise<void
     console.log(`📋 Specified files/directories: ${options.files.join(', ')}\n`);
   }
 
-  // Load .docsignore patterns
+  // Load ignore patterns
   const ignoreFilePath = getIgnoreFilePath(config);
   const ignorePatterns = ignoreFilePath ? loadDocsignorePatterns(ignoreFilePath) : [];
   if (options.verbose) {
-    console.log(`📋 Loaded ${ignorePatterns.length} patterns from .docsignore\n`);
+    console.log(`📋 Loaded ${ignorePatterns.length} ignore patterns\n`);
   }
 
-  // Filter files not excluded by .docsignore
+  // Filter files not excluded by ignore patterns
   const markdownFiles = allMarkdownFiles.filter((file) => {
     const relativePath = path.relative(config.projectRoot, file);
     return !isIgnored(relativePath, ignorePatterns);
@@ -118,7 +118,7 @@ export async function main(args: string[] = process.argv.slice(2)): Promise<void
 
   if (options.verbose && allMarkdownFiles.length > markdownFiles.length) {
     console.log(
-      `📋 ${allMarkdownFiles.length - markdownFiles.length} files excluded by .docsignore\n`
+      `📋 ${allMarkdownFiles.length - markdownFiles.length} files excluded by ignore patterns\n`
     );
   }
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -39,7 +39,6 @@ describe('Config System', () => {
         expect(config).toEqual({
           projectRoot: testDir,
           docsDir: 'docs',
-          ignoreFile: '.docsignore',
           verbose: false,
         });
       });
@@ -219,7 +218,7 @@ describe('Config System', () => {
 
         expect(config.docsDir).toBe('custom-docs');
         expect(config.projectRoot).toBe(testDir);
-        expect(config.ignoreFile).toBe('.docsignore');
+        expect(config.ignoreFile).toBeUndefined();
       });
     });
 
@@ -320,8 +319,9 @@ describe('Config System', () => {
 
     describe('getIgnoreFilePath', () => {
       it('should return absolute path to ignore file when configured', () => {
-        const ignorePath = getIgnoreFilePath(config);
-        expect(ignorePath).toBe(path.join(testDir, '.docsignore'));
+        const customConfig = loadConfig({ ignoreFile: '.gitignore' });
+        const ignorePath = getIgnoreFilePath(customConfig);
+        expect(ignorePath).toBe(path.join(testDir, '.gitignore'));
       });
 
       it('should return null when ignoreFile is not configured', () => {
@@ -343,13 +343,12 @@ describe('Config System', () => {
       const docsDir = path.join(testDir, 'docs');
       fs.mkdirSync(docsDir);
       fs.writeFileSync(path.join(docsDir, 'README.md'), '# Documentation');
-      fs.writeFileSync(path.join(testDir, '.docsignore'), '*.tmp.md');
 
       const config = loadConfig();
 
       expect(config.projectRoot).toBe(testDir);
       expect(getDocsPath(config)).toBe(docsDir);
-      expect(getIgnoreFilePath(config)).toBe(path.join(testDir, '.docsignore'));
+      expect(getIgnoreFilePath(config)).toBeNull();
     });
 
     it('should handle monorepo structure with custom docsDir', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ export interface CodeRefConfig {
   docsDir: string;
 
   /**
-   * Path to ignore file relative to projectRoot (default: ".docsignore")
+   * Path to ignore file relative to projectRoot
    */
   ignoreFile?: string;
 
@@ -80,7 +80,6 @@ function getDefaultConfig(): CodeRefConfig {
   return {
     projectRoot: process.cwd(),
     docsDir: 'docs',
-    ignoreFile: '.docsignore',
     verbose: false,
   };
 }

--- a/src/core/validate.test.ts
+++ b/src/core/validate.test.ts
@@ -14,7 +14,6 @@ const mockProjectRoot = '/project';
 const mockConfig: CodeRefConfig = {
   projectRoot: mockProjectRoot,
   docsDir: 'docs',
-  ignoreFile: '.docsignore',
   verbose: false,
 };
 

--- a/src/utils/fix.test.ts
+++ b/src/utils/fix.test.ts
@@ -50,7 +50,6 @@ const mockPrompt = prompt as jest.Mocked<typeof prompt>;
 const mockConfig: CodeRefConfig = {
   projectRoot: path.resolve(__dirname, '../../..'),
   docsDir: 'docs',
-  ignoreFile: '.docsignore',
   verbose: false,
 };
 


### PR DESCRIPTION
## Issue

#11 

BREAKING CHANGE: The `ignoreFile` configuration no longer defaults to '.docsignore'. To continue using .docsignore, explicitly set `ignoreFile: '.docsignore'` in your configuration file (.coderefrc.json or package.json).

This change makes the ignore file behavior explicit rather than implicit, applying ignore patterns only when intentionally configured. All documentation examples now use `.gitignore` instead of `.docsignore` to reflect this generic approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)